### PR TITLE
feat: add Umami analytics script for page visit tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -29,7 +29,7 @@
     <meta name="twitter:image" content="/images/social-networks-preview.png" />
     <title>Pablo Avilés Prieto portfolio</title>
     <script
-      defer
+      async
       src="https://analytics.pabloaviles.dev/script.js"
       data-website-id="345980bf-c73a-4283-b665-296e50a98bdf"
     ></script>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,11 @@
     />
     <meta name="twitter:image" content="/images/social-networks-preview.png" />
     <title>Pablo Avilés Prieto portfolio</title>
+    <script
+      defer
+      src="https://analytics.pabloaviles.dev/script.js"
+      data-website-id="345980bf-c73a-4283-b665-296e50a98bdf"
+    ></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Add the Umami analytics script to `index.html` to track page visits on the portfolio
- Script loads deferred from `analytics.pabloaviles.dev` with the configured website ID

## Test plan
- [ ] Deploy or preview the site and confirm the Umami script loads without console errors
- [ ] Verify a page view appears in the Umami dashboard after visiting the site